### PR TITLE
[cmd/validate] add a flag to require names for all resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ createdResources:
   # Default is false.
   strict: true
 
+  # Set to true if you want Akashi to validate the ruleset specifies names for
+  # created resources.
+  # Default is false.
+  requireName: true
+
   # Default compare options to apply to all resources.
   # If a resource specifies the same option, the resource's value will be used.
   default:
@@ -149,6 +154,11 @@ updatedResources:
   # Set to true if you want all updated resources to match a rule.
   # Default is false.
   strict: true
+
+  # Set to true if you want Akashi to validate the ruleset specifies names for
+  # updated resources.
+  # Default is false.
+  requireName: true
 
   # Default compare options to apply to all resources.
   # If a resource specifies the same option, the resource's value will be used.

--- a/cmd/akashi.go
+++ b/cmd/akashi.go
@@ -10,6 +10,7 @@ import (
 	"github.com/drlau/akashi/internal/compare"
 	comparecmd "github.com/drlau/akashi/pkg/cmd/compare"
 	diffcmd "github.com/drlau/akashi/pkg/cmd/diff"
+	validatecmd "github.com/drlau/akashi/pkg/cmd/validate"
 	versioncmd "github.com/drlau/akashi/pkg/cmd/version"
 	"github.com/drlau/akashi/pkg/plan"
 	"github.com/drlau/akashi/pkg/utils"
@@ -52,6 +53,7 @@ func NewCommand() *cobra.Command {
 
 	cmd.AddCommand(comparecmd.NewCmdCompare())
 	cmd.AddCommand(diffcmd.NewCmdDiff())
+	cmd.AddCommand(validatecmd.NewCmd())
 	cmd.AddCommand(versioncmd.NewCmdVersion(os.Stdout, version))
 
 	return cmd

--- a/internal/compare/compare.go
+++ b/internal/compare/compare.go
@@ -1,12 +1,9 @@
 package compare
 
 import (
-	"io/ioutil"
-
 	"github.com/drlau/akashi/pkg/compare"
 	"github.com/drlau/akashi/pkg/plan"
 	"github.com/drlau/akashi/pkg/ruleset"
-	yaml "gopkg.in/yaml.v2"
 )
 
 type Comparer interface {
@@ -22,13 +19,8 @@ type ComparerSet struct {
 
 func NewComparerSet(path string) (ComparerSet, error) {
 	result := ComparerSet{}
-	rulesetFile, err := ioutil.ReadFile(path)
-	if err != nil {
-		return result, err
-	}
 
-	var rs ruleset.Ruleset
-	err = yaml.Unmarshal(rulesetFile, &rs)
+	rs, err := ruleset.ParseRuleset(path)
 	if err != nil {
 		return result, err
 	}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -1,0 +1,13 @@
+package validate
+
+import (
+	"github.com/drlau/akashi/pkg/ruleset"
+)
+
+type ValidateResult struct {
+	Valid bool
+}
+
+func Validate(ruleset ruleset.Ruleset) *ValidateResult {
+	return &ValidateResult{}
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -5,9 +5,54 @@ import (
 )
 
 type ValidateResult struct {
-	Valid bool
+	InvalidCreatedResources   []*ruleset.ResourceIdentifier
+	InvalidDestroyedResources []*ruleset.ResourceIdentifier
+	InvalidUpdatedResources   []*ruleset.ResourceIdentifier
 }
 
-func Validate(ruleset ruleset.Ruleset) *ValidateResult {
-	return &ValidateResult{}
+func (r *ValidateResult) fill_defaults() {
+	if r.InvalidCreatedResources == nil {
+		r.InvalidCreatedResources = make([]*ruleset.ResourceIdentifier, 0)
+	}
+	if r.InvalidDestroyedResources == nil {
+		r.InvalidDestroyedResources = make([]*ruleset.ResourceIdentifier, 0)
+	}
+	if r.InvalidUpdatedResources == nil {
+		r.InvalidUpdatedResources = make([]*ruleset.ResourceIdentifier, 0)
+	}
+}
+
+func (r *ValidateResult) IsValid() bool {
+	createdValid := len(r.InvalidCreatedResources) == 0
+	destroyedValid := len(r.InvalidDestroyedResources) == 0
+	updatedValid := len(r.InvalidUpdatedResources) == 0
+	return createdValid && destroyedValid && updatedValid
+}
+
+func getUnnamedResources[T ruleset.Resource](rs []T) []*ruleset.ResourceIdentifier {
+	var res []*ruleset.ResourceIdentifier
+	for _, r := range rs {
+		id := r.ID()
+		if id.Name == "" {
+			res = append(res, id)
+		}
+	}
+	return res
+}
+
+func Validate(rs ruleset.Ruleset) *ValidateResult {
+	res := &ValidateResult{}
+	if rs.CreatedResources != nil && rs.CreatedResources.RequireName {
+		ids := getUnnamedResources(rs.CreatedResources.Resources)
+		res.InvalidCreatedResources = ids
+	}
+	if rs.DestroyedResources != nil && rs.DestroyedResources.RequireName {
+		ids := getUnnamedResources(rs.DestroyedResources.Resources)
+		res.InvalidDestroyedResources = ids
+	}
+	if rs.UpdatedResources != nil && rs.UpdatedResources.RequireName {
+		ids := getUnnamedResources(rs.UpdatedResources.Resources)
+		res.InvalidUpdatedResources = ids
+	}
+	return res
 }

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -1,0 +1,145 @@
+package validate
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/drlau/akashi/pkg/ruleset"
+)
+
+func TestValidate(t *testing.T) {
+	tests := map[string]struct {
+		rs       ruleset.Ruleset
+		expected *ValidateResult
+	}{
+		"valid ruleset without required names": {
+			rs: ruleset.Ruleset{
+				CreatedResources: &ruleset.CreateDeleteResourceChanges{
+					Strict:      false,
+					RequireName: false,
+					Resources: []ruleset.CreateDeleteResourceChange{
+						{
+							ResourceIdentifier: ruleset.ResourceIdentifier{
+								Type: "google_project_service",
+								Name: "api",
+							},
+						},
+						{
+							ResourceIdentifier: ruleset.ResourceIdentifier{
+								Type: "google_service_account",
+							},
+						},
+					},
+				},
+			},
+			expected: &ValidateResult{},
+		},
+		"valid ruleset with required names": {
+			rs: ruleset.Ruleset{
+				CreatedResources: &ruleset.CreateDeleteResourceChanges{
+					Strict:      false,
+					RequireName: true,
+					Resources: []ruleset.CreateDeleteResourceChange{
+						{
+							ResourceIdentifier: ruleset.ResourceIdentifier{
+								Type: "google_project_service",
+								Name: "api",
+							},
+						},
+						{
+							ResourceIdentifier: ruleset.ResourceIdentifier{
+								Type: "google_service_account",
+								Name: "my_service_account",
+							},
+						},
+					},
+				},
+			},
+			expected: &ValidateResult{},
+		},
+		"invalid ruleset": {
+			rs: ruleset.Ruleset{
+				CreatedResources: &ruleset.CreateDeleteResourceChanges{
+					Strict:      false,
+					RequireName: true,
+					Resources: []ruleset.CreateDeleteResourceChange{
+						{
+							ResourceIdentifier: ruleset.ResourceIdentifier{
+								Type: "google_project_service",
+							},
+						},
+					},
+				},
+			},
+			expected: &ValidateResult{
+				InvalidCreatedResources: []*ruleset.ResourceIdentifier{
+					{Type: "google_project_service"},
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			res := Validate(test.rs)
+			if diff := cmp.Diff(res, test.expected); diff != "" {
+				t.Errorf("Validate() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIsValid(t *testing.T) {
+	tests := map[string]struct {
+		res      ValidateResult
+		expected bool
+	}{
+		"no invalid resources": {
+			res:      ValidateResult{},
+			expected: true,
+		},
+		"invalid created resources": {
+			res: ValidateResult{
+				InvalidCreatedResources: []*ruleset.ResourceIdentifier{
+					{Type: "fake_created_resource"},
+				},
+			},
+			expected: false,
+		},
+		"invalid destroyed resources": {
+			res: ValidateResult{
+				InvalidDestroyedResources: []*ruleset.ResourceIdentifier{
+					{Type: "fake_destroy_resource"},
+				},
+			},
+			expected: false,
+		},
+		"invalid updated resources": {
+			res: ValidateResult{
+				InvalidUpdatedResources: []*ruleset.ResourceIdentifier{
+					{Type: "fake_update_resource"},
+				},
+			},
+			expected: false,
+		},
+		"multiple invalid resources changes": {
+			res: ValidateResult{
+				InvalidCreatedResources: []*ruleset.ResourceIdentifier{
+					{Type: "fake_created_resource"},
+				},
+				InvalidUpdatedResources: []*ruleset.ResourceIdentifier{
+					{Type: "fake_update_resource"},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if test.res.IsValid() != test.expected {
+				t.Errorf("Expected %t, got %t: %v", test.expected, test.res.IsValid(), test.res)
+			}
+		})
+	}
+}

--- a/pkg/cmd/validate/validate.go
+++ b/pkg/cmd/validate/validate.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// TODO: print out which resources are not valid
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "validate <path to ruleset>",
@@ -28,10 +27,14 @@ func NewCmd() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ruleset, err := ruleset.ParseRuleset(args[0])
-			if res := validate.Validate(ruleset); !res.IsValid() {
-				return fmt.Errorf("ruleset is invalid")
+			if err != nil {
+				return fmt.Errorf("Could not parse ruleset: %v", err)
 			}
-			return err
+			if res := validate.Validate(ruleset); !res.IsValid() {
+				return fmt.Errorf("%s", res.String())
+			}
+			fmt.Println("Ruleset is valid!")
+			return nil
 		},
 	}
 	return cmd

--- a/pkg/cmd/validate/validate.go
+++ b/pkg/cmd/validate/validate.go
@@ -1,0 +1,29 @@
+package validate
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "validate <path to ruleset>",
+		Short: "Validte the ruleset",
+		Long:  "Validate the ruleset, exiting with code 0 if the ruleset is valid",
+
+		// NOTE: We explicitly do not set Args with ExactArgs(1) since that
+		// will not print the help message.
+		PreRunE: func(cmd *cobra.Command, args []string) err {
+			if len(args) == 0 {
+				cmd.Help()
+				os.Exit(1)
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) err {
+			return nil
+		},
+	}
+}

--- a/pkg/cmd/validate/validate.go
+++ b/pkg/cmd/validate/validate.go
@@ -1,12 +1,14 @@
 package validate
 
 import (
-	"fmt"
 	"os"
+
+	"github.com/drlau/akashi/pkg/ruleset"
 
 	"github.com/spf13/cobra"
 )
 
+// TODO: print out which resources are not valid
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "validate <path to ruleset>",
@@ -15,15 +17,17 @@ func NewCmd() *cobra.Command {
 
 		// NOTE: We explicitly do not set Args with ExactArgs(1) since that
 		// will not print the help message.
-		PreRunE: func(cmd *cobra.Command, args []string) err {
-			if len(args) == 0 {
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
 				cmd.Help()
 				os.Exit(1)
 			}
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, args []string) err {
-			return nil
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, err := ruleset.ParseRuleset(args[0])
+			return err
 		},
 	}
+	return cmd
 }

--- a/pkg/cmd/validate/validate.go
+++ b/pkg/cmd/validate/validate.go
@@ -28,7 +28,7 @@ func NewCmd() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ruleset, err := ruleset.ParseRuleset(args[0])
-			if res := validate.Validate(ruleset); !res.Valid {
+			if res := validate.Validate(ruleset); !res.IsValid() {
 				return fmt.Errorf("ruleset is invalid")
 			}
 			return err

--- a/pkg/cmd/validate/validate.go
+++ b/pkg/cmd/validate/validate.go
@@ -2,7 +2,9 @@ package validate
 
 import (
 	"os"
+	"fmt"
 
+	"github.com/drlau/akashi/internal/validate"
 	"github.com/drlau/akashi/pkg/ruleset"
 
 	"github.com/spf13/cobra"
@@ -25,7 +27,10 @@ func NewCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			_, err := ruleset.ParseRuleset(args[0])
+			ruleset, err := ruleset.ParseRuleset(args[0])
+			if res := validate.Validate(ruleset); !res.Valid {
+				return fmt.Errorf("ruleset is invalid")
+			}
 			return err
 		},
 	}

--- a/pkg/ruleset/ruleset.go
+++ b/pkg/ruleset/ruleset.go
@@ -1,5 +1,11 @@
 package ruleset
 
+import (
+	"io/ioutil"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
 type Ruleset struct {
 	CreatedResources   *CreateDeleteResourceChanges `yaml:"createdResources,omitempty"`
 	DestroyedResources *CreateDeleteResourceChanges `yaml:"destroyedResources,omitempty"`
@@ -88,4 +94,15 @@ type EnforceChange struct {
 	Value         interface{}              `yaml:"value,omitempty"`
 	MatchAny      []interface{}            `yaml:"matchAny,omitempty"`
 	EnforceChange map[string]EnforceChange `yaml:",inline"`
+}
+
+func ParseRuleset(path string) (Ruleset, error) {
+	var rs Ruleset
+	rulesetFile, err := ioutil.ReadFile(path)
+	if err != nil {
+		return rs, err
+	}
+
+	err = yaml.Unmarshal(rulesetFile, &rs)
+	return rs, err
 }

--- a/pkg/ruleset/ruleset.go
+++ b/pkg/ruleset/ruleset.go
@@ -6,6 +6,10 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+type Resource interface {
+	ID() *ResourceIdentifier
+}
+
 type Ruleset struct {
 	CreatedResources   *CreateDeleteResourceChanges `yaml:"createdResources,omitempty"`
 	DestroyedResources *CreateDeleteResourceChanges `yaml:"destroyedResources,omitempty"`
@@ -25,6 +29,10 @@ type CreateDeleteResourceChanges struct {
 
 	// Resources is a list of resource changes to validate against
 	Resources []CreateDeleteResourceChange `yaml:"resources"`
+}
+
+func (r CreateDeleteResourceChange) ID() *ResourceIdentifier {
+	return &r.ResourceIdentifier
 }
 
 type CreateDeleteResourceChange struct {
@@ -54,6 +62,10 @@ type UpdateResourceChange struct {
 
 	Before *ResourceRules `yaml:"before,omitempty"`
 	After  *ResourceRules `yaml:"after,omitempty"`
+}
+
+func (r UpdateResourceChange) ID() *ResourceIdentifier {
+	return &r.ResourceIdentifier
 }
 
 type CompareOptions struct {

--- a/pkg/ruleset/ruleset.go
+++ b/pkg/ruleset/ruleset.go
@@ -10,6 +10,10 @@ type CreateDeleteResourceChanges struct {
 	// If strict is enabled, all created or deleted resources must match a rule
 	Strict bool `yaml:"strict,omitempty"`
 
+	// If requireName is enabled, all resources must specify the name of the
+	// resource in addition to the resource type
+	RequireName bool `yaml:"requireName",omitempty`
+
 	// Default CompareOptions to use for all resources
 	Default *CompareOptions `yaml:"default,omitempty"`
 
@@ -26,6 +30,10 @@ type CreateDeleteResourceChange struct {
 type UpdateResourceChanges struct {
 	// If strict is enabled, all updated resources must match a rule
 	Strict bool `yaml:"strict,omitempty"`
+
+	// If requireName is enabled, all resources must specify the name of the
+	// resource in addition to the resource type
+	RequireName bool `yaml:"requireName",omitempty`
 
 	// Default CompareOptions to use for all resources
 	Default *CompareOptions `yaml:"default,omitempty"`

--- a/pkg/ruleset/ruleset.go
+++ b/pkg/ruleset/ruleset.go
@@ -1,6 +1,7 @@
 package ruleset
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	yaml "gopkg.in/yaml.v2"
@@ -95,6 +96,13 @@ type ResourceIdentifier struct {
 	Type string `yaml:"type,omitempty"`
 	// TODO: index
 	// Index interface{} `yaml:"index,omitempty"`
+}
+
+func (id *ResourceIdentifier) String() string {
+	if id.Name == "" {
+		return id.Type
+	}
+	return fmt.Sprintf("%s.%s", id.Type, id.Name)
 }
 
 type ResourceRules struct {


### PR DESCRIPTION
While targeting all instances of a specific resource type is convenient,
sometimes we want to ensure we're not being too broad with our changes.
This `requireName` key can be used to ensure that all resources in the
ruleset are explicitly named.